### PR TITLE
isMobile() has moved under a 'device' key in aframe utils

### DIFF
--- a/src/ar-scene.js
+++ b/src/ar-scene.js
@@ -40,8 +40,8 @@ AFRAME.registerElement('ar-scene', {
     
     createdCallback: {
       value: function () {
-        this.isMobile = AFRAME.utils.isMobile();
-        this.isIOS = AFRAME.utils.isIOS();
+        this.isMobile = (AFRAME.utils.isMobile || AFRAME.utils.device.isMobile)();
+        this.isIOS = (AFRAME.utils.isIOS || AFRAME.utils.device.isIOS)();
         this.isScene = true;
         this.isArgon = true;        
         this.object3D = new THREE.Scene();


### PR DESCRIPTION
See https://github.com/aframevr/aframe/pull/2044 for more details.